### PR TITLE
Fix broken write_output method. #3

### DIFF
--- a/au_notebook.py
+++ b/au_notebook.py
@@ -299,10 +299,10 @@ class au_notebook:
         :return: None.
         """
         try:
-            with open(filename, "w") as output:
+            with open(stdout, "w") as output:
                 for value in results:
-                    output_file_write(str(value))
-        except:
+                    output.write(str(value))
+        except Exception as exp:
             print("Error writing the file.")
 
     def sentiment_scores(self, by="domain"):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ description = \
 
 setup(
     name='au_notebook',
-    version='0.0.2',
+    version='0.0.3',
     url='https://github.com/archivesunleashed/au_notebook',
     install_requires=['matplotlib', 'networkx', 'nltk', 'numpy', 'pandas'],
     author='Ryan Deschamps, Nick Ruest',


### PR DESCRIPTION
Fixes bug where write_output was broken.  This occurred for two reasons:

1. The local parameter filename was change in the call to stdout, but not changed in the function.
2. The function referred to a no-longer-in-existence "output_write_file" function.

To test (without pypi test):

Fetch or clone repo.
cd au_notebook
pip uninstall au-notebook
python -m pip install ./

Launch notebook and test.
NOTE:  The current output file request should say `nb.write_output( etc.)` now instead of just `write_output( etc)`.

If for some reason, you already had the notebook running before you updated au_notebook, you will need to restart the notebook and import cells before the module will take effect.
